### PR TITLE
Moving toward making LyA_fit_start.py a real start file

### DIFF
--- a/LyA_fit_start.py
+++ b/LyA_fit_start.py
@@ -99,6 +99,9 @@ variables[p]['vary'] = True
 variables[p]['scale'] = 1.
 variables[p]['min'] = -100.
 variables[p]['max'] = 100.
+variables[p]['Gaussian prior'] = False
+variables[p]['prior mean'] = 0
+variables[p]['prior stddev'] = 0
 
 p = 'am_n'
 variables[p]['texname'] = r'$log A_n$'
@@ -107,6 +110,9 @@ variables[p]['vary'] = True
 variables[p]['scale'] = 0.1
 variables[p]['min'] = -16.
 variables[p]['max'] = -12.
+variables[p]['Gaussian prior'] = False
+variables[p]['prior mean'] = 0
+variables[p]['prior stddev'] = 0
 
 p = 'fw_n'
 variables[p]['texname'] = r'$FW_n$'
@@ -115,6 +121,9 @@ variables[p]['vary'] = True
 variables[p]['scale'] = 5.
 variables[p]['min'] = 50.
 variables[p]['max'] = 275.
+variables[p]['Gaussian prior'] = False
+variables[p]['prior mean'] = 0
+variables[p]['prior stddev'] = 0
 
 p = 'vs_b'
 variables[p]['texname'] = r'$v_b$'
@@ -126,6 +135,9 @@ else:
 variables[p]['scale'] = 1.
 variables[p]['min'] = -100.
 variables[p]['max'] = 100.
+variables[p]['Gaussian prior'] = False
+variables[p]['prior mean'] = 0
+variables[p]['prior stddev'] = 0
 
 p = 'am_b'
 variables[p]['texname'] = r'$log A_b$'
@@ -138,6 +150,9 @@ variables[p]['scale'] = 0.1
 variables[p]['min'] = -19.
 variables[p]['max'] = -13.
 variables[p]['single_comp'] = single_component_switch
+variables[p]['Gaussian prior'] = False
+variables[p]['prior mean'] = 0
+variables[p]['prior stddev'] = 0
 
 p = 'fw_b'
 variables[p]['texname'] = r'$FW_b$'
@@ -149,6 +164,9 @@ else:
 variables[p]['scale'] = 50.
 variables[p]['min'] = 500.
 variables[p]['max'] = 2000.
+variables[p]['Gaussian prior'] = False
+variables[p]['prior mean'] = 0
+variables[p]['prior stddev'] = 0
 
 p = 'h1_col'
 variables[p]['texname'] = r'$log N(HI)$'
@@ -157,6 +175,9 @@ variables[p]['vary'] = True
 variables[p]['scale'] = 0.2
 variables[p]['min'] = 16.
 variables[p]['max'] = 18.5
+variables[p]['Gaussian prior'] = False
+variables[p]['prior mean'] = 0
+variables[p]['prior stddev'] = 0
 
 p = 'h1_b' #  h1_b_true = 11.5 - for a T=8000 K standard ISM
 variables[p]['texname'] = r'$b$',
@@ -165,6 +186,9 @@ variables[p]['vary'] = True
 variables[p]['scale'] = 0.2
 variables[p]['min'] = 1.
 variables[p]['max'] = 20.
+variables[p]['Gaussian prior'] = False
+variables[p]['prior mean'] = 0
+variables[p]['prior stddev'] = 0
 
 p = 'h1_vel'
 variables[p]['texname'] = r'$v_{HI}$'
@@ -173,6 +197,9 @@ variables[p]['vary'] = False
 variables[p]['scale'] = 1.
 variables[p]['min'] = -50.
 variables[p]['max'] = 50.
+variables[p]['Gaussian prior'] = False
+variables[p]['prior mean'] = 0
+variables[p]['prior stddev'] = 0
 
 p = 'd2h' # Fixing the D/H ratio at 1.5e-5.  (Wood+ 2004 is the reference, I believe)
 variables[p]['texname'] = r'$D/H$'
@@ -182,6 +209,9 @@ variables[p]['scale'] = 0
 variables[p]['min'] = 1e-5
 variables[p]['max'] = 2e-5
 variables[p]['resolution'] = resolution
+variables[p]['Gaussian prior'] = False
+variables[p]['prior mean'] = 0
+variables[p]['prior stddev'] = 0
 
 ## This is the order of the parameters that the profile function needs!
 param_order = ['vs_n', 'am_n', 'fw_n', 'vs_b', 'am_b', 'fw_b', 'h1_col', 'h1_b', 'h1_vel', 'd2h']

--- a/LyA_fit_start.py
+++ b/LyA_fit_start.py
@@ -7,8 +7,7 @@ import astropy.io.fits as pyfits
 import lya_plot
 import copy
 
-## 17 Jan 2018 - To Do: add example for Gaussian priors.
-    
+
 import matplotlib.pyplot as plt
 
 
@@ -20,6 +19,7 @@ input_filename = 'p_msl_pan_-----_gj176_panspec_native_resolution_waverange1100.
 ## Set fitting parameters
 do_emcee = True      # do MCMC fitting (no other options)
 start_uniform = True # starting positions for MCMC are uniform (alternate: Gaussian)
+single_component_switch = True
 # for single component flux, set variables['am_b']['single_comp'] = False
 
 ## Read in the data ##
@@ -99,7 +99,10 @@ variables[p]['max'] = 275.
 p = 'vs_b'
 variables[p]['texname'] = r'$v_b$'
 variables[p]['value'] = 34.
-variables[p]['vary'] = True
+if single_component_switch == False:
+  variables[p]['vary'] = True
+else:
+  variables[p]['vary'] = False
 variables[p]['scale'] = 1.
 variables[p]['min'] = -100.
 variables[p]['max'] = 100.
@@ -107,16 +110,22 @@ variables[p]['max'] = 100.
 p = 'am_b'
 variables[p]['texname'] = r'$log A_b$'
 variables[p]['value'] = -13.68
-variables[p]['vary'] = True
+if single_component_switch == False:
+  variables[p]['vary'] = True
+else:
+  variables[p]['vary'] = False
 variables[p]['scale'] = 0.1
 variables[p]['min'] = -19.
 variables[p]['max'] = -13.
-variables[p]['single_comp'] = False
+variables[p]['single_comp'] = single_component_switch
 
 p = 'fw_b'
 variables[p]['texname'] = r'$FW_b$'
 variables[p]['value'] = 547.
-variables[p]['vary'] = True
+if single_component_switch == False:
+  variables[p]['vary'] = True
+else:
+  variables[p]['vary'] = False
 variables[p]['scale'] = 50.
 variables[p]['min'] = 500.
 variables[p]['max'] = 2000.

--- a/LyA_fit_start.py
+++ b/LyA_fit_start.py
@@ -208,10 +208,10 @@ variables[p]['vary'] = False
 variables[p]['scale'] = 0
 variables[p]['min'] = 1e-5
 variables[p]['max'] = 2e-5
-variables[p]['resolution'] = resolution
 variables[p]['Gaussian prior'] = False
 variables[p]['prior mean'] = 0
 variables[p]['prior stddev'] = 0
+variables[p]['resolution'] = resolution
 
 ## This is the order of the parameters that the profile function needs!
 param_order = ['vs_n', 'am_n', 'fw_n', 'vs_b', 'am_b', 'fw_b', 'h1_col', 'h1_b', 'h1_vel', 'd2h']

--- a/lyapy.py
+++ b/lyapy.py
@@ -532,7 +532,7 @@ def lnprior(theta, minmax, prior_Gauss, prior_list):
     
     return priors
 
-def lnlike(theta, x, y, yerr, resolution, singcomp=False):
+def lnlike(theta, x, y, yerr, resolution, singcomp=False, HAW=False):
     vs_n, am_n, fw_n, vs_b, am_b, fw_b, h1_col, h1_b, h1_vel, d2h = theta
     #y_model = damped_lya_profile(x,vs_n,10**am_n,fw_n,vs_b,10**am_b,fw_b,h1_col,
     #                                   h1_b,h1_vel,d2h=d2h,resolution=resolution,
@@ -544,10 +544,7 @@ def lnlike(theta, x, y, yerr, resolution, singcomp=False):
 
     return -0.5 * np.sum(np.log(2 * np.pi * yerr**2) + (y - y_model) ** 2 / yerr**2)
 
-## add a new function that is very similar to damped_lya_profile_shortcut - or just
-## modify lnprob or whatever to intake damped_lya_profile_shortcut instead of damped_lya_profile.
-## Then create lya_intrinsic_profile from multiple calls to lya_intrinsic_profile_func
-#damped_lya_profile_shortcut(wave_to_fit,resolution,lya_intrinsic_profile,total_tau_profile)
+
 
 
 def lnprob(theta, x, y, yerr, variables):
@@ -579,5 +576,78 @@ def lnprob(theta, x, y, yerr, variables):
     #if np.random.uniform() > 0.9995: print "took a step!", theta_all
     ll = lnlike(theta_all, x, y, yerr, resolution = variables['d2h']['resolution'],
                                        singcomp = variables['am_b']['single_comp'])
+    return lp + ll
+
+
+
+def lnprior_g140l(theta, minmax, prior_Gauss, prior_list):
+    assert len(theta) == len(minmax)
+
+    vs_n, am_n, fw_n, vs_b, am_b, fw_b, h1_col, h1_b, h1_vel, d2h, vs_haw, am_haw, fw_haw = theta
+    
+    priors = 0
+    for i in range(len(theta)):
+        if (theta[i] < minmax[i][0]) or (theta[i] > minmax[i][1]): # a parameter is out of range
+            return -np.inf
+        if prior_Gauss[i]: # Gaussian prior, else uniform prior (0 or np.log(h1_b))
+            priors += -0.5*((theta[i]-prior_list[i][0])/prior_list[i][1])**2
+        elif (i == 7) and not prior_Gauss[7]: # h1_b
+            priors += np.log(h1_b)
+        else:
+            priors += 0 # not necessary, just included for clarity/completeness
+            
+    # ... no parameter was out of range
+    
+    return priors
+
+###
+
+def lnlike_g140l(theta, x, y, yerr, resolution, singcomp=False, HAW=False):
+    vs_n, am_n, fw_n, vs_b, am_b, fw_b, h1_col, h1_b, h1_vel, d2h, vs_haw, am_haw, fw_haw = theta
+    #y_model = damped_lya_profile(x,vs_n,10**am_n,fw_n,vs_b,10**am_b,fw_b,h1_col,
+    #                                   h1_b,h1_vel,d2h=d2h,resolution=resolution,
+    #                                   single_component_flux=singcomp)/1e14
+    intr_profile = lya_intrinsic_profile_func(x,vs_n,10**am_n,fw_n,vs_b,10**am_b,fw_b,
+                   single_component_flux=singcomp)
+    if HAW: #Huge Ass Wings
+      haw_profile = lya_intrinsic_profile_func(x,vs_haw,10**am_haw,fw_haw,single_component_flux=True)
+      intr_profile += haw_profile
+    tau = total_tau_profile_func(x,h1_col,h1_b,h1_vel,d2h=d2h)
+    y_model = damped_lya_profile_shortcut(x,resolution,intr_profile,tau)/1e14
+
+    return -0.5 * np.sum(np.log(2 * np.pi * yerr**2) + (y - y_model) ** 2 / yerr**2)
+
+
+def lnprob_g140l(theta, x, y, yerr, variables):
+    order = ['vs_n', 'am_n', 'fw_n', 'vs_b', 'am_b', 'fw_b', 'h1_col', 'h1_b', 'h1_vel', 'd2h',
+             'vs_haw', 'am_haw', 'fw_haw']
+    theta_all = []
+    range_all = []
+    prior_Gauss = [] # Boolean list for whether or not the parameter has a Gaussian prior
+    prior_list = []
+    i = 0
+    for p in order:
+        range_all.append( [variables[p]['min'],variables[p]['max']] )
+        if variables[p]['vary']:
+            theta_all.append(theta[i])
+            i = i+1
+        else:
+            theta_all.append(variables[p]['value'])
+        if variables[p]['Gaussian prior']:
+            prior_Gauss.append(True)
+            prior_list.append([variables[p]['prior mean'],variables[p]['prior stddev']])
+        else:
+            prior_Gauss.append(False)
+            prior_list.append(0)
+                
+    assert (i) == len(theta)
+    lp = lnprior_g140l(theta_all, range_all, prior_Gauss, prior_list)
+    if not np.isfinite(lp):
+        return -np.inf
+
+    #if np.random.uniform() > 0.9995: print "took a step!", theta_all
+    ll = lnlike_g140l(theta_all, x, y, yerr, resolution = variables['d2h']['resolution'],
+                                       singcomp = variables['am_b']['single_comp'],
+                                       HAW = variables['vs_haw']['HAW'])
     return lp + ll
 

--- a/lyapy.py
+++ b/lyapy.py
@@ -533,9 +533,9 @@ def lnprior(theta, minmax, prior_Gauss, prior_list):
     
     return priors
 
-def lnlike(theta, x, y, yerr, singcomp=False):
+def lnlike(theta, x, y, yerr, resolution, singcomp=False):
     vs_n, am_n, fw_n, vs_b, am_b, fw_b, h1_col, h1_b, h1_vel, d2h = theta
-    y_model = lyapy.damped_lya_profile(x,vs_n,10**am_n,fw_n,vs_b,10**am_b,fw_b,h1_col,
+    y_model = damped_lya_profile(x,vs_n,10**am_n,fw_n,vs_b,10**am_b,fw_b,h1_col,
                                        h1_b,h1_vel,d2h=d2h,resolution=resolution,
                                        single_component_flux=singcomp)/1e14
 
@@ -568,6 +568,7 @@ def lnprob(theta, x, y, yerr, variables):
         return -np.inf
 
     #if np.random.uniform() > 0.9995: print "took a step!", theta_all
-    ll = lnlike(theta_all, x, y, yerr, singcomp = variables['am_b']['single_comp'])
+    ll = lnlike(theta_all, x, y, yerr, resolution = variables['d2h']['resolution'],
+                                       singcomp = variables['am_b']['single_comp'])
     return lp + ll
 

--- a/lyapy.py
+++ b/lyapy.py
@@ -350,7 +350,6 @@ def damped_lya_profile_shortcut(wave_to_fit,resolution,lya_intrinsic_profile,tot
 
     return lyman_fit*1e14
 
-
 def make_kernel(grid,fwhm,nfwhm=4.):
 
     """
@@ -535,11 +534,21 @@ def lnprior(theta, minmax, prior_Gauss, prior_list):
 
 def lnlike(theta, x, y, yerr, resolution, singcomp=False):
     vs_n, am_n, fw_n, vs_b, am_b, fw_b, h1_col, h1_b, h1_vel, d2h = theta
-    y_model = damped_lya_profile(x,vs_n,10**am_n,fw_n,vs_b,10**am_b,fw_b,h1_col,
-                                       h1_b,h1_vel,d2h=d2h,resolution=resolution,
-                                       single_component_flux=singcomp)/1e14
+    #y_model = damped_lya_profile(x,vs_n,10**am_n,fw_n,vs_b,10**am_b,fw_b,h1_col,
+    #                                   h1_b,h1_vel,d2h=d2h,resolution=resolution,
+    #                                   single_component_flux=singcomp)/1e14
+    intr_profile = lya_intrinsic_profile_func(x,vs_n,10**am_n,fw_n,vs_b,10**am_b,fw_b,
+                   single_component_flux=singcomp)
+    tau = total_tau_profile_func(x,h1_col,h1_b,h1_vel,d2h=d2h)
+    y_model = damped_lya_profile_shortcut(x,resolution,intr_profile,tau)/1e14
 
     return -0.5 * np.sum(np.log(2 * np.pi * yerr**2) + (y - y_model) ** 2 / yerr**2)
+
+## add a new function that is very similar to damped_lya_profile_shortcut - or just
+## modify lnprob or whatever to intake damped_lya_profile_shortcut instead of damped_lya_profile.
+## Then create lya_intrinsic_profile from multiple calls to lya_intrinsic_profile_func
+#damped_lya_profile_shortcut(wave_to_fit,resolution,lya_intrinsic_profile,total_tau_profile)
+
 
 def lnprob(theta, x, y, yerr, variables):
     order = ['vs_n', 'am_n', 'fw_n', 'vs_b', 'am_b', 'fw_b', 'h1_col', 'h1_b', 'h1_vel', 'd2h']

--- a/lyapy.py
+++ b/lyapy.py
@@ -512,4 +512,49 @@ def ready_stis_lsf(orig_lsf_wave,orig_lsf,stis_grating_disp,data_wave):
 
   return lsf_interp_norm
 
+## Define priors and likelihoods, where parameters are fixed
+def lnprior(theta, minmax):
+    assert len(theta) == len(minmax)
+    
+    for i in range(len(theta)):
+        if (theta[i] < minmax[i][0]) or (theta[i] > minmax[i][1]): # a parameter is out of range
+            return -np.inf
+    # ... no parameter was out of range
+    vs_n, am_n, fw_n, vs_b, am_b, fw_b, h1_col, h1_b, h1_vel, d2h = theta
+    return np.log(h1_b)
+
+def lnlike(theta, x, y, yerr, resolution, singcomp=False):
+    vs_n, am_n, fw_n, vs_b, am_b, fw_b, h1_col, h1_b, h1_vel, d2h = theta
+    y_model = damped_lya_profile(x,vs_n,10**am_n,fw_n,vs_b,10**am_b,fw_b,h1_col,
+                                       h1_b,h1_vel,d2h=d2h,resolution=resolution,
+                                       single_component_flux=singcomp)/1e14
+
+    return -0.5 * np.sum(np.log(2 * np.pi * yerr**2) + (y - y_model) ** 2 / yerr**2)
+
+def lnprob(theta, x, y, yerr, variables):
+    order = ['vs_n', 'am_n', 'fw_n', 'vs_b', 'am_b', 'fw_b', 'h1_col', 'h1_b', 'h1_vel', 'd2h']
+    theta_all = []
+    range_all = []
+    i = 0
+    for p in order:
+        range_all.append( [variables[p]['min'],variables[p]['max']] )
+        if variables[p]['vary']:
+            theta_all.append(theta[i])
+            i = i+1
+        else:
+            theta_all.append(variables[p]['value'])
+                
+    assert (i) == len(theta)
+    lp = lnprior(theta_all, range_all)
+    if not np.isfinite(lp):
+        return -np.inf
+
+    #if np.random.uniform() > 0.9995: print "took a step!", theta_all
+    ll = lnlike(theta_all, x, y, yerr, resolution = variables['d2h']['resolution'], 
+                                       singcomp = variables['am_b']['single_comp'])
+    return lp + ll
+
+
+## Could include an example for how to change any of these to a Gaussian prior
+
 


### PR DESCRIPTION
Moved lnprob functions into lyapy. Added a switch for single vs. two component fit at the top. Removed the do_emcee parameter since that's all lyapy does now (no mpfit). And I did a substantial re-organization of LyA_fit_start.py. Should be easier to read, and all of the modifiable parameters (except the variable dictionary) are located at the top of the file.